### PR TITLE
Screenshots & Memory-Log

### DIFF
--- a/sdcard/memory-log/README.md
+++ b/sdcard/memory-log/README.md
@@ -1,0 +1,7 @@
+# Memory Log
+### Logs swap details & memory usage 
+
+* Starts 60 seconds after the autorun script is executed
+* Log file location 'memLog/memory.log'
+* Log entry once every 60 seconds
+* Logs swap usage (/proc/swaps) and memory info (/proc/meminfo)

--- a/sdcard/memory-log/memLog/monitor.sh
+++ b/sdcard/memory-log/memLog/monitor.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Momory Monitor Log - 20 entries, 60 seconds apart
+MYDIR=$(dirname "$(readlink -f "$0")")
+LOGFILE="${MYDIR}/memory.log"
+# rm -f "${LOGFILE}"
+echo "**** START MEMORY LOG - ${timestamp} ****" >> "${LOGFILE}"
+sleep 60
+for i in $(seq 1 20)
+do
+	sleep 60
+	timestamp=$(date +%s)
+	echo "********* LOG - ${timestamp} ********" >> "${LOGFILE}"
+	cat /proc/swaps >> "${LOGFILE}"
+	cat /proc/meminfo >> "${LOGFILE}"
+done
+exit

--- a/sdcard/memory-log/run.sh
+++ b/sdcard/memory-log/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Disable watchdog
+echo 1 > /sys/class/gpio/Watchdog\ Disable/value
+mount -o rw,remount /
+# Set environment
+DIR=$(dirname $(readlink -f $0))
+
+sh ${DIR}/memLog/monitor.sh &
+

--- a/sdcard/screenshots/README.md
+++ b/sdcard/screenshots/README.md
@@ -1,0 +1,7 @@
+# Screenshots
+
+### Takes X screenshots over an interval amount of time
+
+* **Set variables in the 'ss/screenshots.conf' file to change amount & frequency of screenshots**
+* Starts 60 seconds after the autorun script is executed
+* Default is 10 screenshots at 60 second intervals 

--- a/sdcard/screenshots/run.sh
+++ b/sdcard/screenshots/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Disable watchdog
+echo 1 > /sys/class/gpio/Watchdog\ Disable/value
+mount -o rw,remount /
+# Set environment
+DIR=$(dirname $(readlink -f $0))
+
+sh ${DIR}/ss/screenshots.sh &
+

--- a/sdcard/screenshots/ss/screenshots.conf
+++ b/sdcard/screenshots/ss/screenshots.conf
@@ -1,0 +1,14 @@
+### NUMSCRNSHOTS
+##  Number of screenshots 
+NUMSCRNSHOTS=10
+
+### SSGAP
+##  Half of the time between screenshots in seconds
+##  It goes screenshot gap save gap shot gap save...
+SSGAP=30
+
+### DONE_MSG
+##  A Pop-up meesage when the screenshots have all finished
+##  1 = Message 0 = No Message
+##  This isnt working right now investigating why...
+DONE_MSG=1

--- a/sdcard/screenshots/ss/screenshots.sh
+++ b/sdcard/screenshots/ss/screenshots.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+MYDIR=$(dirname "$(readlink -f "$0")")
+CONFIGFILE="${MYDIR}/screenshots.conf"
+SDDIR="/tmp/mnt/sd_nav/"
+SSGAP=30
+NUMSCRNSHOTS=10
+DONE_MESSAGE=0
+. ${CONFIGFILE}
+# echo "=${NUMSCRNSHOTS}= =${SSGAP}= =${DONE_MESSAGE}=" >> ${MYDIR}/sstest.log
+sleep 60
+if [ ! -e ${SDDIR}/screenshots ]
+then
+	mkdir -p ${SDDIR}/screenshots
+fi
+for i in $(seq 1 $NUMSCRNSHOTS)
+do
+	/usr/bin/screenshot
+	sleep ${SSGAP}
+	cp /wayland-screenshot.png ${SDDIR}/screenshots/screenshot${i}.png
+	sleep ${SSGAP}
+done
+if [ ${DONE_MESSAGE} = 1 ]
+then
+	killall jci-dialog
+	/jci/tools/jci-dialog --info --title="AIO-SCREENSHOTS" --text="${NUMSCRNSHOTS} SCREENSHOTS TAKEN" --no-cancel &
+	sleep 3
+	killall jci-dialog
+fi
+exit


### PR DESCRIPTION
Screenshots can be set to X screenshots with Y interval gaps starting 60 seconds after the autorun script is executed.
Memory-Log logs swap usage and memory info to a file with 60 second intervals